### PR TITLE
fix(claims): fix uppercase addresses

### DIFF
--- a/src/components/WizardStep1.vue
+++ b/src/components/WizardStep1.vue
@@ -126,6 +126,7 @@ export default defineComponent({
     watch(
       () => step1State.manuallyEnteredAccount,
       newVal => {
+        step1State.manuallyEnteredAccount = newVal.toLowerCase();
         const isValid = props.wizardState.web3Inst.utils.isAddress(newVal);
         step1State.manuallyEnteredAccountValid = isValid;
         if (!isValid) step1State.notClaimableAddress = false;


### PR DESCRIPTION
in step 1 typing or pasting the ethereum address uppercase caused the claim to fail. forced lowercase to fix.